### PR TITLE
:bug: closes #114 - fixed positioning of input field and capitalized …

### DIFF
--- a/src/lib/atoms/NavFilterList.svelte
+++ b/src/lib/atoms/NavFilterList.svelte
@@ -65,7 +65,7 @@
 						d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"
 					/><path d="M21 21l-6 -6" /></svg
 				>
-				zoeken
+				Zoeken
 			</button>
 		</fieldset>
 	</form>
@@ -144,6 +144,7 @@
 		gap: var(--unit-small);
 		border: unset;
 		margin: auto;
+		align-items: center;
 	}
 
 	form input:nth-of-type(1),
@@ -188,7 +189,7 @@
 		color: var(--color-white);
 		background-color: #593bff;
 		font-size: var(--unit-default);
-		border: unset;
+		border: 2px solid transparent;
 		position: relative;
 		transition: var(--animation-default) ease-in-out;
 		display: flex;


### PR DESCRIPTION
# Description
Ik heb de zoekknop een hoofdletter gegeven en de zoekbalk gecentreerd.

Dit was niet netjes qua styling en consistency
*After*
<img width="915" alt="Screenshot 2024-04-16 at 11 47 20" src="https://github.com/MokhtarAkle/grote-themas-sprint-19/assets/112855849/aa9407f9-4d2c-457a-afc7-53d642a91d52">
[grote-themas-sprint-19-rosy.vercel.app](https://grote-themas-sprint-19-rosy.vercel.app/)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] User test
- [x] Responsive Design test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have written meaningful commit messages
- [x] I have performed a self-review of my code



